### PR TITLE
Expand FEM multi-measurement RoomEQ QA

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -550,60 +550,54 @@ qa-roomeq-small-stereo-51: ensure-venv
 	done
 
 # ----------------------------------------------------------------------
-# QA ROOMEQ — Multi-Measurement (5 listening positions per speaker)
-# Tests the multi-objective optimization across all strategies.
-# Requires data generated with 5 LPs (run `just generate-roomeq-data` first).
+# QA ROOMEQ — Multi-Measurement
+# Tests every generated FEM scenario across all multi-measurement strategies,
+# then exercises focused home-cinema and height-channel feature configurations.
+# Requires generated data (run `just generate-roomeq-data` first).
 # ----------------------------------------------------------------------
 
 [group('qa-roomeq-multi')]
-qa-roomeq-multi-measurement: \
-	qa-roomeq-multi-small-stereo-20 \
-	qa-roomeq-multi-small-stereo-21 \
-	qa-roomeq-multi-small-stereo-22-mso
-
-[group('qa-roomeq-multi')]
-qa-roomeq-multi-small-stereo-20: ensure-venv
-	@for strategy in minimax weighted_sum variance_penalized; do \
-	  for algo in fem; do \
-	    mkdir -p ./data_generated/roomeq/generated/$algo/small_stereo_2_0; \
-	    echo "=== Multi-measurement $strategy ($algo) small_stereo_2_0 ==="; \
+qa-roomeq-multi-measurement: ensure-venv
+	#!/usr/bin/env bash
+	set -euo pipefail
+	scenario_root="./data_tests/roomeq/generate/fem"
+	override_root="./data_tests/roomeq/generate/optimiser-config/multi_measurement"
+	output_root="./data_generated/roomeq/generated/fem"
+	shopt -s nullglob
+	configs=("$scenario_root"/*/config.json)
+	if (( ${#configs[@]} == 0 )); then
+	  echo "No FEM RoomEQ scenarios found under $scenario_root" >&2
+	  exit 1
+	fi
+	for config in "${configs[@]}"; do
+	  scenario="$(basename "$(dirname "$config")")"
+	  scenario_output="$output_root/$scenario"
+	  mkdir -p "$scenario_output"
+	  for strategy in minimax weighted_sum variance_penalized; do
+	    output="$scenario_output/dsp_iir_multi_$strategy.json"
+	    echo "=== Multi-measurement $strategy (fem) $scenario ==="
 	    cargo run --bin roomeq --release -- \
-	      --config       ./data_tests/roomeq/generate/$algo/small_stereo_2_0/config.json \
-	      --override-config ./data_tests/roomeq/generate/optimiser-config/multi_measurement/$strategy.json \
-	      --output       ./data_generated/roomeq/generated/$algo/small_stereo_2_0/dsp_iir_multi_$strategy.json; \
-	    ./venv/bin/python3 ./scripts/display-roomeq.py \
-	                     ./data_generated/roomeq/generated/$algo/small_stereo_2_0/dsp_iir_multi_$strategy.json; \
-	  done \
+	      --config "$config" \
+	      --override-config "$override_root/$strategy.json" \
+	      --output "$output"
+	    ./venv/bin/python3 ./scripts/display-roomeq.py "$output"
+	  done
 	done
-
-[group('qa-roomeq-multi')]
-qa-roomeq-multi-small-stereo-21: ensure-venv
-	@for strategy in minimax weighted_sum variance_penalized; do \
-	  for algo in fem; do \
-	    mkdir -p ./data_generated/roomeq/generated/$algo/small_stereo_2_1; \
-	    echo "=== Multi-measurement $strategy ($algo) small_stereo_2_1 ==="; \
-	    cargo run --bin roomeq --release -- \
-	      --config       ./data_tests/roomeq/generate/$algo/small_stereo_2_1/config.json \
-	      --override-config ./data_tests/roomeq/generate/optimiser-config/multi_measurement/$strategy.json \
-	      --output       ./data_generated/roomeq/generated/$algo/small_stereo_2_1/dsp_iir_multi_$strategy.json; \
-	    ./venv/bin/python3 ./scripts/display-roomeq.py \
-	                     ./data_generated/roomeq/generated/$algo/small_stereo_2_1/dsp_iir_multi_$strategy.json; \
-	  done \
-	done
-
-[group('qa-roomeq-multi')]
-qa-roomeq-multi-small-stereo-22-mso: ensure-venv
-	@for strategy in minimax weighted_sum variance_penalized; do \
-	  for algo in fem; do \
-	    mkdir -p ./data_generated/roomeq/generated/$algo/small_stereo_2_2_mso; \
-	    echo "=== Multi-measurement $strategy ($algo) small_stereo_2_2_mso ==="; \
-	    cargo run --bin roomeq --release -- \
-	      --config       ./data_tests/roomeq/generate/$algo/small_stereo_2_2_mso/config.json \
-	      --override-config ./data_tests/roomeq/generate/optimiser-config/multi_measurement/$strategy.json \
-	      --output       ./data_generated/roomeq/generated/$algo/small_stereo_2_2_mso/dsp_iir_multi_$strategy.json; \
-	    ./venv/bin/python3 ./scripts/display-roomeq.py \
-	                     ./data_generated/roomeq/generated/$algo/small_stereo_2_2_mso/dsp_iir_multi_$strategy.json; \
-	  done \
+	for feature_case in \
+	  "medium_surround_5_1:home_cinema_lfe_only" \
+	  "medium_surround_5_1_4:home_cinema_redirected" \
+	  "medium_surround_5_1_4:height_channel_alignment"; do
+	  scenario="${feature_case%%:*}"
+	  feature="${feature_case#*:}"
+	  config="$scenario_root/$scenario/config.json"
+	  override="$override_root/features/$feature.json"
+	  output="$output_root/$scenario/dsp_iir_multi_$feature.json"
+	  echo "=== Multi-measurement feature pass $feature (fem) $scenario ==="
+	  cargo run --bin roomeq --release -- \
+	    --config "$config" \
+	    --override-config "$override" \
+	    --output "$output"
+	  ./venv/bin/python3 ./scripts/display-roomeq.py "$output"
 	done
 
 # New comprehensive QA using roomeq-qa-full binary

--- a/data_tests/roomeq/generate/optimiser-config/multi_measurement/features/height_channel_alignment.json
+++ b/data_tests/roomeq/generate/optimiser-config/multi_measurement/features/height_channel_alignment.json
@@ -1,0 +1,41 @@
+{
+  "system": null,
+  "optimizer": {
+    "multi_measurement": {
+      "strategy": "variance_penalized",
+      "variance_lambda": 1.0
+    },
+    "inter_channel_timbre_matching": {
+      "enabled": true,
+      "reference_channel": "center",
+      "min_improvement_db": 0.05
+    },
+    "height_channel_alignment": {
+      "enabled": true,
+      "match_timbre": true,
+      "match_level": true,
+      "match_arrival_time": true,
+      "match_phase": true,
+      "min_timbre_improvement_db": 0.05,
+      "max_delay_ms": 20.0,
+      "reference_channels": {
+        "top_front": "left",
+        "top_rear": "surround_left"
+      }
+    },
+    "target_response": {
+      "shape": "from_measurement",
+      "broadband_precorrection": true,
+      "role_targets": {
+        "enabled": true,
+        "center_dialog_boost_db": 1.0,
+        "height_treble_shelf_db": -1.0,
+        "surround_treble_shelf_db": -0.5,
+        "cinema_x_curve_enabled": true,
+        "cinema_x_curve_start_hz": 2000.0,
+        "cinema_x_curve_db_per_octave": -0.5,
+        "listening_distance_m": 5.0
+      }
+    }
+  }
+}

--- a/data_tests/roomeq/generate/optimiser-config/multi_measurement/features/home_cinema_lfe_only.json
+++ b/data_tests/roomeq/generate/optimiser-config/multi_measurement/features/home_cinema_lfe_only.json
@@ -1,0 +1,74 @@
+{
+  "system": {
+    "model": "home_cinema",
+    "speakers": {
+      "L": "left",
+      "R": "right",
+      "C": "center",
+      "SL": "surround_left",
+      "SR": "surround_right",
+      "LFE": "lfe"
+    },
+    "subwoofers": {
+      "config": "single",
+      "crossover": "first",
+      "lfe": "L"
+    },
+    "bass_management": {
+      "enabled": true,
+      "redirect_bass": false,
+      "lfe_channel": "LFE",
+      "lfe_playback_gain_db": 10.0,
+      "apply_lfe_gain_to_chain": true,
+      "sub_trim_db": -1.5,
+      "max_sub_boost_db": 4.0,
+      "headroom_margin_db": 6.0,
+      "optimize_groups": false
+    }
+  },
+  "optimizer": {
+    "multi_measurement": {
+      "strategy": "weighted_sum"
+    },
+    "phase_alignment": {
+      "enabled": true,
+      "min_freq": 50.0,
+      "max_freq": 120.0,
+      "optimize_polarity": true,
+      "max_delay_ms": 20.0
+    },
+    "group_delay": {
+      "enabled": true,
+      "max_delay_ms": 20.0,
+      "ap_per_channel": 2,
+      "ap_min_q": 0.3,
+      "ap_max_q": 10.0,
+      "optimize_polarity": true,
+      "coherence_threshold": 0.8,
+      "min_improvement_db": 0.5,
+      "max_iter": 200,
+      "popsize": 10,
+      "tol": 0.000001,
+      "adaptive_allpass": true
+    },
+    "inter_channel_timbre_matching": {
+      "enabled": true,
+      "reference_channel": "C",
+      "min_improvement_db": 0.05
+    },
+    "target_response": {
+      "shape": "from_measurement",
+      "broadband_precorrection": true,
+      "role_targets": {
+        "enabled": true,
+        "center_dialog_boost_db": 1.0,
+        "center_dialog_low_hz": 300.0,
+        "center_dialog_high_hz": 4000.0,
+        "cinema_x_curve_enabled": true,
+        "cinema_x_curve_start_hz": 2000.0,
+        "cinema_x_curve_db_per_octave": -0.5,
+        "listening_distance_m": 4.0
+      }
+    }
+  }
+}

--- a/data_tests/roomeq/generate/optimiser-config/multi_measurement/features/home_cinema_redirected.json
+++ b/data_tests/roomeq/generate/optimiser-config/multi_measurement/features/home_cinema_redirected.json
@@ -1,0 +1,91 @@
+{
+  "system": {
+    "model": "home_cinema",
+    "speakers": {
+      "L": "left",
+      "R": "right",
+      "C": "center",
+      "SL": "surround_left",
+      "SR": "surround_right",
+      "TFL": "top_front_left",
+      "TFR": "top_front_right",
+      "TRL": "top_rear_left",
+      "TRR": "top_rear_right",
+      "LFE": "lfe"
+    },
+    "subwoofers": {
+      "config": "single",
+      "crossover": "first",
+      "lfe": "L"
+    },
+    "bass_management": {
+      "enabled": true,
+      "redirect_bass": true,
+      "lfe_channel": "LFE",
+      "lfe_playback_gain_db": 10.0,
+      "apply_lfe_gain_to_chain": false,
+      "sub_trim_db": 0.0,
+      "max_sub_boost_db": 6.0,
+      "headroom_margin_db": 6.0,
+      "group_crossovers": {
+        "lcr": "first",
+        "surround": "first",
+        "height": "first"
+      },
+      "optimize_groups": true,
+      "headroom_model": {
+        "model": "cinema_correlated",
+        "lr_correlation": 0.75,
+        "lcr_correlation": 0.5,
+        "surround_height_correlation": 0.35
+      }
+    }
+  },
+  "optimizer": {
+    "multi_measurement": {
+      "strategy": "variance_penalized",
+      "variance_lambda": 1.0
+    },
+    "phase_alignment": {
+      "enabled": true,
+      "min_freq": 50.0,
+      "max_freq": 120.0,
+      "optimize_polarity": true,
+      "max_delay_ms": 20.0
+    },
+    "group_delay": {
+      "enabled": true,
+      "max_delay_ms": 20.0,
+      "ap_per_channel": 2,
+      "ap_min_q": 0.3,
+      "ap_max_q": 10.0,
+      "optimize_polarity": true,
+      "coherence_threshold": 0.8,
+      "min_improvement_db": 0.5,
+      "max_iter": 200,
+      "popsize": 10,
+      "tol": 0.000001,
+      "adaptive_allpass": true
+    },
+    "inter_channel_timbre_matching": {
+      "enabled": true,
+      "reference_channel": "C",
+      "min_improvement_db": 0.05
+    },
+    "target_response": {
+      "shape": "from_measurement",
+      "broadband_precorrection": true,
+      "role_targets": {
+        "enabled": true,
+        "center_dialog_boost_db": 1.0,
+        "height_treble_shelf_db": -1.0,
+        "surround_treble_shelf_db": -0.5,
+        "lfe_bass_shelf_db": 2.0,
+        "cinema_x_curve_enabled": true,
+        "cinema_x_curve_start_hz": 2000.0,
+        "cinema_x_curve_db_per_octave": -0.5,
+        "listening_distance_m": 5.0
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #37.

## Summary

- Discover and execute all 20 FEM RoomEQ scenarios across minimax, weighted-sum, and variance-penalized multi-measurement strategies.
- Add focused LFE-only and redirected/grouped home-cinema bass-management passes with phase alignment, group-delay optimization, role targets, and inter-channel timbre matching.
- Add a 5.1.4 generic-topology pass that exercises height-channel alignment on the FEM height measurements.

## Verification

- All 60 scenario/strategy combinations passed `roomeq --dry-run`.
- All 3 feature overrides passed `roomeq --dry-run`.
- Real `medium_surround_5_1` LFE-only optimization passed; timbre matching applied and group-delay completed.
- Real `medium_surround_5_1_4` redirected optimization passed; grouped bass routing, timbre matching, and group-delay completed.
- Real `medium_surround_5_1_4` height optimization passed; timbre matching applied and height alignment ran degraded due magnitude-only FEM phase/arrival limits.
- `display-roomeq.py` rendered all three feature outputs.
- `just --dry-run qa-roomeq-multi-measurement`
- `jq empty` on all new overrides.
- `git diff --check`

## Skipped

- The full 63-run optimization matrix was not run end-to-end; all merges were dry-run validated and all three focused feature paths were run fully.
